### PR TITLE
Correction de package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
   "dependencies": {
     "express": "^4.18.2",
     "fs": "^0.0.1-security",
-    "path": "^0.12.7",
+    "path": "^0.12.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.18.2",
+    "express-fileupload": "^1.5.0",
     "fs": "^0.0.1-security",
     "path": "^0.12.7"
   }


### PR DESCRIPTION
Première modification : Une erreur de syntaxe empêche l'installation des paquets, une virgule qui traine en trop

![WindowsTerminal_LeJGIkzJod](https://github.com/masterdpro/sharex-custom-uploader-express/assets/93478889/655ae230-43e9-474b-a100-6476db0b70fc)
